### PR TITLE
feat: provide sample data by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ cypress
 # exclude coverage
 /coverage
 .nyc_output
+
+# exclude local database
+db.json

--- a/data/default.json
+++ b/data/default.json
@@ -1,0 +1,49 @@
+{
+  "appInstanceResources": [],
+  "appInstances": [
+    {
+      "_id": "6156e70ab253020033364411",
+      "settings": {},
+      "item": "2356e70ab2530200333634a2",
+      "createdAt" : "2019-01-01T00:00:00.000Z",
+      "updatedAt" : "2019-01-01T00:00:00.000Z"
+    }
+  ],
+  "spaces": [
+    {
+      "_id": "5b56e70ab253020033364411"
+    }
+  ],
+  "lightUsers": [
+    {
+      "id": "5b56e70ab253020033364416",
+      "name": "juan carlos",
+      "spaceId": "5b56e70ab253020033364411"
+    },
+    {
+      "id": "5c055c1083d22e0211c24ad8",
+      "name": "pamela",
+      "spaceId": "5b56e70ab253020033364411"
+    },
+    {
+      "id": "5c055c1083d22e0211c24ad9",
+      "name": "joana",
+      "spaceId": "5b56e70ab253020033364411"
+    },
+    {
+      "id": "5c055c1083d22e0211c24ad6",
+      "name": "maria",
+      "spaceId": "5b56e70ab253020033364411"
+    },
+    {
+      "id": "5c055c1083d22e0211c24ad1",
+      "name": "andré",
+      "spaceId": "5b56e70ab253020033364411"
+    },
+    {
+      "id": "5c055c1083d22e0211c24ad1",
+      "name": "mashkour",
+      "spaceId": "5b56e70ab253020033364411"
+    }
+  ]
+}

--- a/data/routes.json
+++ b/data/routes.json
@@ -1,5 +1,9 @@
 {
+  "/app-instances/:id": "/appInstances/:id",
   "/app-instance-resources\\?appInstanceId=:id": "/appInstanceResources?appInstance=:id",
+  "/app-instance-resources\\?userId=:id": "/appInstanceResources?user=:id",
+  "/app-instance-resources\\?appInstanceId=:appInstanceId\\&userId=:userId": "/appInstanceResources?appInstance=:appInstanceId&user=:userId",
   "/app-instance-resources": "/appInstanceResources",
-  "/app-instance-resources/:id": "/appInstanceResources/:id"
+  "/app-instance-resources/:id": "/appInstanceResources/:id",
+  "/spaces/:spaceId/light-users": "/spaces/:spaceId/lightUsers"
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "start:api": "json-server --watch data/db.json --port 3636 --id _id --routes data/routes.json",
+    "start:local": "env-cmd ./.env.local yarn start",
+    "start:api": "yarn reset:api && json-server --watch data/db.json --port 3636 --id _id --routes data/routes.json",
+    "reset:api": "cat data/default.json > data/db.json",
     "build": "yarn build:react && yarn build:bundle",
     "build:react": "react-scripts build",
     "build:bundle": "webpack --config webpack.config.js --mode=production",


### PR DESCRIPTION
Provide users, a space and an app instance by default. Also ignore the
db.json file to avoid cluttering. Local database cleans up every time
it is started.

closes #44